### PR TITLE
AtomPairs should complain nicely when required argument is not passed

### DIFF
--- a/src/python/metrics/contact.py
+++ b/src/python/metrics/contact.py
@@ -276,7 +276,7 @@ class AtomPairs(Vectorized, AbstractDistanceMetric):
             n, m = atom_pairs.shape
             if not m == 2:
                 raise ValueError()
-        except ValueError:
+        except ValueError, TypeError:
             raise ValueError('Atom pairs must be an n x 2 array of pairs of atoms')
         self.atom_pairs = np.int32(atom_pairs)
         


### PR DESCRIPTION
I got bored of seeing this error

```
    atom_pairs = np.array(atom_pairs, dtype=int)
TypeError: long() argument must be a string or a number, not 'NoneType'
```

which is caused by not supplying a required keyword argument to the AtomPairs constructor. This PR makes the error message more meaningful.
