### PR TITLE
Supresses PEP3118 warning, fix bug in builder

### DIFF
--- a/scripts/ConvertDataToHDF.py
+++ b/scripts/ConvertDataToHDF.py
@@ -34,7 +34,7 @@ def run(projectfn, PDBfn, InputDir, source, min_length, stride, rmsd_cutoff):
     else:
         update = False
     
-    logger.info("Looking for %s stype data in %s", source, InputDir)
+    logger.info("Looking for %s style data in %s", source, InputDir)
     if update:
         raise NotImplementedError("Ack! Update mode is not yet ready yet.")
     

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ metadata = {
     'install_requires': ['scipy', 'matplotlib', 'pyyaml',
                          'deap', 'fastcluster==1.1.6'],
     'platforms': ["Linux", "Mac OS X"],
+    'zip_safe': False,
     'description': "Python Code for Building Markov State Models",
     'long_description': """MSMBuilder (https://simtk.org/home/msmbuilder)
 is a library that provides tools for analyzing molecular dynamics

--- a/src/python/dcd.py
+++ b/src/python/dcd.py
@@ -30,6 +30,7 @@ from ctypes import Structure, POINTER, c_float, c_double, CDLL, c_char_p, c_int
 from ctypes import c_void_p, byref
 from ctypes.util import find_library
 import imp
+import warnings
 
 # define handle to dcd library as global variable (but it should only be used within this module)
 _dcdlib = None
@@ -192,7 +193,12 @@ class DCDReader:
         self._nextframe += self._stepframe
 
         # create a "coords" numpy array for returning
-        coords = np.asfarray(np.array(xyzvec).reshape(self.natoms.value, 3))
+        with warnings.catch_warnings():
+            # supress the PEP3118 warning
+            # http://stackoverflow.com/questions/4964101/pep-3118-warning-when-using-ctypes-array-as-numpy-array
+            warnings.simplefilter("ignore")
+            coords = np.asfarray(np.array(xyzvec).reshape(self.natoms.value, 3))
+            
         if self._atomindices != None:
             coords = coords[self._atomindices, ]
         coords = coords * 0.1       # \AA -> nm

--- a/src/python/project/builder.py
+++ b/src/python/project/builder.py
@@ -220,7 +220,7 @@ class ProjectBuilder(object):
             traj = Trajectory.load_from_xtc(file_list, PDBFilename=self.conf_filename,
                         discard_overlapping_frames=True)
         elif self.input_traj_ext == '.dcd':
-            traj = Trajectory.load_from_xtc(file_list, PDBFilename=self.conf_filename)
+            traj = Trajectory.load_from_dcd(file_list, PDBFilename=self.conf_filename)
         else:
             raise ValueError()
         return traj


### PR DESCRIPTION
Supres PEP3118 Error in dcd.py
Fix bug in builder where it was calling `load_from_xtc` even when `input_type_ext' == '.dcd'`
