### PR TITLE
(Bug?)fix in msm_analysis.calc_expectation_timeseries

### DIFF
--- a/src/python/msm_analysis.py
+++ b/src/python/msm_analysis.py
@@ -542,10 +542,15 @@ def calc_expectation_timeseries(tprob, observable, init_pop=None, timepoints=10 
     """
 
     # first, perform the eigendecomposition
-    lambd, psi_L = sparse_eigen(tprob.T, k=n_modes, which='LR')
-    #lambd, psi_R = get_eigenvectors(tprob, n_modes, right=True)
+    lambd, psi_L = get_eigenvectors(tprob, n_modes, right=False)
     psi_L = np.real(psi_L)
     lambd = np.real(lambd)
+
+    pos_ind = np.where(lambd > 0)[0]
+    lambd = lambd[pos_ind]
+    psi_L = psi_L[:, pos_ind]
+    n_modes = len(lambd)
+    logger.info("Found %d non-negative eigenvalues" % n_modes)
 
     # normalize eigenvectors
     pi = psi_L[:, 0]


### PR DESCRIPTION
Changed eigendecomposition in msm_analysis.calc_expectation_timeseries to use msm_analysis.get_eigenvectors rather than scipy.sparse.linalg.eigs. The reason I think this is necessary is I was having issues calculating eigenvalues using eigs directly. For instance on one MSM, I was calculating the top 250, but the stationary eigenvector did not end up in the returned set. I  do not understand why, and could not repeat it with a smaller MSM (mine was 19k states). Secondly, however, it is better practice to reuse our own eigendecomposition code anyway, so from a purely engineering perspective this is the right way to do it anyway. I also added a check to remove negative eigenvalues. Numerically this can happen, but they have no physical meaning, and so we should ignore them when calculating observables.
