### PR TITLE
Added functionality to use CLoader / CDumper from yaml

### DIFF
--- a/src/python/project/project.py
+++ b/src/python/project/project.py
@@ -19,6 +19,15 @@
 import os
 import numpy as np
 import yaml
+# if CLoader/CDumper are available (i.e. user has libyaml installed)
+#  then use them since they are much faster.
+try:
+    from yaml import CLoader as Loader
+    from yaml import CDumper as Dumper
+except ImportError:
+    from yaml import Loader
+    from yaml import Dumper
+
 from msmbuilder import Trajectory
 from msmbuilder import io
 from msmbuilder import MSMLib
@@ -141,7 +150,7 @@ class Project(object):
 
         if filename.endswith('.yaml'):
             with open(filename) as f:
-                ondisk = yaml.load(f)
+                ondisk = yaml.load(f, Loader=Loader)
                 records = {'conf_filename': ondisk['conf_filename'],
                            'traj_lengths': [],
                            'traj_paths': [],
@@ -212,7 +221,7 @@ class Project(object):
                                     'length': int(self._traj_lengths[i]),
                                     'errors': self._traj_errors[i]})
 
-        yaml.dump(records, handle)
+        yaml.dump(records, handle, Dumper=Dumper)
 
         if own_fid:
             handle.close()


### PR DESCRIPTION
This takes advantage of a c-library (libyaml) if its available for faster loads and saves.

For ProjectInfo's that are from F@H data you have large files (several MB) which may not seem very big, but loading a file can be a pain:

```
vspm24:f14g schwancr$ cat load.py
from msmbuilder import Project
p = Project.load_from('ProjectInfo.yaml')

vspm24:f14g schwancr$ time python load.py 

real    2m44.604s
user    2m37.429s
sys 0m3.438s
```

But if you use libyaml:

```
vspm24:f14g schwancr$ time python load.py 

real    0m20.194s
user    0m19.483s
sys 0m0.702s
```

Which is much more convenient in my opinion
