### PR TITLE
bugfix for msmbuilder issue #247 regarding loading prepared trajectories...

### DIFF
--- a/scripts/Cluster.py
+++ b/scripts/Cluster.py
@@ -187,7 +187,7 @@ def cluster(metric, trajectories, ptrajs, args, **kwargs):
     elif args.alg == 'hierarchical':
         zmatrix_fn = kwargs['zmatrix_fn']
         clusterer = clustering.Hierarchical(metric, trajectories=trajectories,
-            prep_trajectories=ptrajs, method=args.hierarchical_method)
+            method=args.hierarchical_method)
         clusterer.save_to_disk(zmatrix_fn)
         logger.info('ZMatrix saved to %s. Use AssignHierarchical.py to assign the data', zmatrix_fn)
     else:
@@ -235,8 +235,10 @@ could stride a little at the begining, but its not recommended.""")
         
     project = Project.load_from(args.project)
 
-    if isinstance(metric, metrics.Vectorized): # if the metric is vectorized then
-        # we can load prepared trajectories which may allow for better memory
+    if isinstance(metric, metrics.Vectorized) and not args.alg == 'hierarchical': 
+        # if the metric is vectorized then
+        # we can load prepared trajectories 
+        # which may allow for better memory
         # efficiency
         ptrajs, which = load_prep_trajectories(project, args.stride, atom_indices, metric)
         trajectories = None


### PR DESCRIPTION
.... If the metric is RMSD or a hybrid metric, then just the trajectories are loaded. But I needed to add a check for LPRMSD, buuuut this doesn't work since it's a plugin. So, the change is to only load prepared trajectories if the metric is in an instance of a subclass of Vectorized. This should work because then we can use np.concatenate on the prepared trajectories. All other metrics are handled by loading trajectories and preparing later.
