### PR TITLE
Fixed bug in clustering and added test.

### DIFF
--- a/src/python/clustering.py
+++ b/src/python/clustering.py
@@ -633,12 +633,12 @@ def _hybrid_kmedoids(metric, ptraj, k=None, distance_cutoff=None, num_iters=10, 
 
     if not np.all(np.unique(medoids) == np.sort(medoids)):
         raise ValueError('Initial medoids must be distinct')
-    if not np.all(np.unique(assignments) == np.sorted(medoids)):
+    if not np.all(np.unique(assignments) == sorted(medoids)):
         raise ValueError('Initial assignments dont match initial medoids')
 
     for iteration in xrange(num_iters):
         for medoid_i in xrange(k):
-            if not np.all(np.unique(assignments) == np.sorted(medoids)):
+            if not np.all(np.unique(assignments) == sorted(medoids)):
                 raise ValueError('Loop invariant lost')
 
             if local_swap is False:

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -170,6 +170,17 @@ class test_Cluster_kcenters(WTempdir):
         eq(distances, np.zeros((1,8)))
 
 
+class test_Cluster_hybrid(WTempdir):
+    # this one tests hybrid kcenters kmedoids
+    def test(self):
+        args, metric = Cluster.parser.parse_args([
+            '-p', get('points_on_cube/ProjectInfo.yaml', just_filename=True),
+            '-o', self.td,
+            'rmsd', '-a', get('points_on_cube/AtomIndices.dat', just_filename=True),
+            'hybrid', '-k', '4'], print_banner=False)
+        Cluster.main(args, metric)
+
+
 class test_Cluster_hierarchical(WTempdir):
     def test(self):
         try:


### PR DESCRIPTION
This fixes a bug I found in the current code: `sorted()` is a python function, not numpy:

```
    if not np.all(np.unique(assignments) == np.sorted(medoids)):
AttributeError: 'module' object has no attribute 'sorted'
```

Also tests whether the hybrid clustering actually runs.
