### PR TITLE
changed discard policy in load_from_xtc and load_from_dcd. 

### DIFF
--- a/src/python/Trajectory.py
+++ b/src/python/Trajectory.py
@@ -384,7 +384,7 @@ class Trajectory(ConformationBaseClass):
                 add_frame = True
                 if discard_overlapping_frames:
                     if i > 0:
-                        if np.sum(np.abs(c.coords - A["XYZList"][-1])) < 1E-8:
+                        if np.all(np.abs(c.coords - A["XYZList"][-1]) < 2E-3):
                             num_redundant += 1
                             add_frame = False
 
@@ -432,7 +432,7 @@ class Trajectory(ConformationBaseClass):
                 add_frame = True
                 if discard_overlapping_frames:
                     if i > 0:
-                        if np.sum(np.abs(coords - A["XYZList"][-1])) < 1E-8:
+                        if np.all(np.abs(coords - A["XYZList"][-1]) < 2E-3):
                             num_redundant += 1
                             add_frame = False
 


### PR DESCRIPTION
This is what I need in order for it to work for me...

I realize that this is a dumb PR since this file is going away in 2.8, but it does point to us needing to deal with redundant frames in FAH projects.

In one of my A4 projects I was not throwing out all redundant frames because every once in a while a single position would be off by 1E-3. These are clearly still the same, so I changed the criterion for checking whether two frames are the same. Obviously this cutoff is empirically based, and maybe it will also fail in some cases...
