### PR TITLE
 More stable eigensolver for reversible transition matrices

### DIFF
--- a/tests/test_eigensolvers.py
+++ b/tests/test_eigensolvers.py
@@ -1,0 +1,32 @@
+import numpy as np
+import scipy.sparse
+import scipy.sparse.linalg
+from msmbuilder.MSMLib import build_msm
+from msmbuilder.msm_analysis import get_eigenvectors, get_reversible_eigenvectors
+
+def test_get_eigenvectors():    
+    # just some random counts
+    N = 100
+    counts = np.random.randint(1, 10, size=(N,N))
+    transmat, pi = build_msm(scipy.sparse.csr_matrix(counts), 'MLE')[1:3]
+
+    values0, vectors0 = get_eigenvectors(transmat, 10)
+    values1, vectors1 = get_reversible_eigenvectors(transmat, 10)
+    values2, vectors2 = get_reversible_eigenvectors(transmat, 10, populations=pi)
+
+    # check that the eigenvalues are the same using the two methods
+    np.testing.assert_array_almost_equal(values0, values1)
+    
+    # check that the eigenvectors returned by both methods are _actually_
+    # left eigenvectors of the transmat
+    def test_eigenpairs(values, vectors):
+        for value, vector in zip(values, vectors.T):
+            np.testing.assert_array_almost_equal(
+                (transmat.T.dot(vector) / vector).flatten(), np.ones(N)*value)
+
+    np.testing.assert_array_almost_equal(pi, vectors0[:, 0])
+    np.testing.assert_array_almost_equal(pi, vectors1[:, 0])
+    np.testing.assert_array_almost_equal(pi, vectors2[:, 0])
+    test_eigenpairs(values0, vectors0)
+    test_eigenpairs(values1, vectors1)
+    test_eigenpairs(values2, vectors2)


### PR DESCRIPTION
From the preface of [Numerical Methods for Large Eigenvalue Problems](http://www-users.cs.umn.edu/~saad/eig_book_2ndEd.pdf), page xv

> In essence what differentiates the Hermitian from the non-Hermitian eigenvalue
> problem is that in the first case we can always manage to compute an approxi-
> mation whereas there are nonsymmetric problems that can be arbitrarily difficult
> to solve and can essentially make any algorithm fail. Stated more rigorously, the
> eigenvalue of a Hermitian matrix is always well-conditioned whereas this is not
> true for nonsymmetric matrices.

Therefore, my _guess_ is that this method (which uses the Hermetian eigensolver for
reversible transition matrices) might be more stable than the existing function in MSMLib
for arbitrary transition matrices, which uses the general eigensolver. I don't actually have
any real evidence for this though -- I haven't tried it on any of the matrices that choke with
`scipy.sparse.linalg.eigs`.

re #307, #311

This is a new copy of the PR, onto master, with https://github.com/SimTk/msmbuilder/pull/311#issuecomment-33724159 taken into account.
