### PR TITLE
Checking for empty states

### DIFF
--- a/src/python/project/project.py
+++ b/src/python/project/project.py
@@ -295,6 +295,8 @@ class Project(object):
                 it is not possible to sample that many conformations without 
                 replacement
             """
+            assert state_counts > 0
+
             if replacement:
                 result = random.randint(0, state_counts, size=size)
             else:
@@ -332,6 +334,9 @@ class Project(object):
 
         for n, state in zip(num_confs, states):
             logger.debug("Working on %s", state)
+            if state_counts[state] == 0:
+                raise ValueError('No conformations to sample from state %d! It contains no assigned conformations.' % state)
+
             random_conf_inds = randomize(state_counts[state], size=n,
                                          replacement=replacement, 
                                          random=random)


### PR DESCRIPTION
Currently, you get an error like this when trying to use SaveStructures.py if a state has no assignments (and thus the variable `state_counts`==0)

```
  File "/home/lilipeng/epd/epd-7.3-2-rh5-x86_64/lib/python2.7/site-packages/msmbuilder-2.8-py2.7-linux-x86_64.egg/msmbuilder/project/project.py", line 299, in randomize
    result = random.randint(0, state_counts, size=size)
  File "mtrand.pyx", line 874, in mtrand.RandomState.randint (numpy/random/mtrand/mtrand.c:5970)
ValueError: low >= high
```

This might be a little more interpretable
