### PR TITLE
bugfix in CalculateProjectDistance.py that wasn't using mdtraj

### DIFF
--- a/scripts/CalculateProjectDistance.py
+++ b/scripts/CalculateProjectDistance.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
     arglib.die_if_path_exists(args.output)
 
     project = Project.load_from(args.project)
-    pdb = Trajectory.load_trajectory_file(args.pdb)
+    pdb = md.load(args.pdb)
     if args.traj_fn.lower() == 'all':
         traj_fn = None
     else:


### PR DESCRIPTION
This speaks to the fact that we don't have a test for this script. What happened to the old CalculateProjectRMSD.py test? We can just adopt that one.
