### PR TITLE
bugfix in contact metric

### DIFF
--- a/MSMBuilder/metrics/contact.py
+++ b/MSMBuilder/metrics/contact.py
@@ -89,7 +89,7 @@ class ContinuousContact(Vectorized, AbstractDistanceMetric):
             1D array of various residue-residue distances
         """
         # the result of md.compute_contacts is a tuple, where the distances are
-        # returned in the first element, and a list of contacts calculate are
+        # returned in the first element, and a list of contacts calculated are
         # returned in the second element
         return md.compute_contacts(trajectory, self.contacts, self.scheme)[0]
 


### PR DESCRIPTION
The contact metric uses mdtraj.compute_contacts, but that method returns both the distances as well as the contacts used. So, prepare_trajectory needs to only select the first element.
